### PR TITLE
Fix undefined variable in error handler

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -475,8 +475,9 @@ def download(
 
     except Exception as e:
         console.print(f"[bold red]Unexpected error: {type(e).__name__}: {e}[/]")
-        if placeholder_pb:
-            placeholder_pb.stop()
+        if EARLY_PB:
+            EARLY_PB.stop()
+            EARLY_PB = None
         sys.exit(3)
 
 


### PR DESCRIPTION
## Summary
- fix reference to undefined `placeholder_pb` variable

## Testing
- `python -m py_compile bwget.py`
- `python bwget.py --version` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_683fe85b3f04832099330195f9e7737e