### PR TITLE
Handle old libtorrent magnet API

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -337,7 +337,11 @@ def download_torrent(url: str, out_dir: Path) -> None:
 
     if url.startswith("magnet:"):
         if use_modern_api and hasattr(lt, "add_magnet_uri"):
-            handle = lt.add_magnet_uri(ses, url, params)
+            try:
+                handle = lt.add_magnet_uri(ses, url, params)
+            except Exception:
+                params = {"save_path": str(out_dir), "url": url}
+                handle = ses.add_torrent(params)
         else:
             if use_modern_api:
                 params.url = url


### PR DESCRIPTION
## Summary
- catch magnet URI errors when libtorrent expects dict
- fall back to `ses.add_torrent` with a simple parameter dict

## Testing
- `python -m py_compile bwget.py`
- `python bwget.py --version`

------
https://chatgpt.com/codex/tasks/task_e_684006a294e48320b45380cb17c4ba31