### PR TITLE
Fix deprecation when retrieving torrent save path

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -402,7 +402,11 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
             num_files = files.num_files() if hasattr(files, "num_files") else files.num_files
             if num_files == 1:
                 rel_path = files.file_path(0)
-                save_root = Path(handle.save_path()) if hasattr(handle, "save_path") else Path(handle.status().save_path)
+                if hasattr(handle, "save_path"):
+                    save_attr = getattr(handle, "save_path")
+                    save_root = Path(save_attr() if callable(save_attr) else save_attr)
+                else:
+                    save_root = Path(handle.status().save_path)
                 file_path = save_root / rel_path
                 if file_path.is_file():
                     verify_sha256_with_progress(file_path, expected_sha256)


### PR DESCRIPTION
## Summary
- handle new libtorrent save_path attribute

## Testing
- `python -m py_compile bwget.py`

------
https://chatgpt.com/codex/tasks/task_e_68400edb2d648320bbfc71ebd884807f