### PR TITLE
Fix torrent progress message

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -375,9 +375,9 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
         handle = ses.add_torrent(params)
 
     status = handle.status()
+    torrent_name = status.name or getattr(handle, "name", lambda: "torrent")()
     console.print(
-        f"[cyan]Downloading torrent to [bold]{escape(str(out_dir))}[/]"
-        f" (seeds: {status.num_seeds}, peers: {status.num_peers})…[/]")
+        f"[cyan]Downloading [bold]{escape(torrent_name)}[/]…[/]")
 
     cols = [
         TextColumn("[green]{task.description}[/] [orange1]{task.percentage:>6.2f}%[/]"),
@@ -388,10 +388,10 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
     ]
 
     with Progress(*cols, console=console, transient=True) as progress:
-        task_id = progress.add_task("Torrent", total=100.0)
+        task_id = progress.add_task(torrent_name, total=100.0)
         while not handle.status().is_seeding:
             s = handle.status()
-            desc = f"Torrent ({s.num_seeds} seeds, {s.num_peers} peers)"
+            desc = f"{torrent_name} ({s.num_seeds} seeds, {s.num_peers} peers)"
             progress.update(task_id, completed=s.progress * 100, description=desc)
             time.sleep(1)
     progress.update(task_id, completed=100)


### PR DESCRIPTION
## Summary
- show the torrent's name instead of output directory when starting
- use torrent name for progress bar and display seeds/peers dynamically

## Testing
- `python3 -m py_compile bwget.py`

------
https://chatgpt.com/codex/tasks/task_e_684013ac426483209eff7c079bb864a8