### PR TITLE
Update torrent status line during download

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -376,9 +376,10 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
 
     status = handle.status()
     torrent_name = status.name or getattr(handle, "name", lambda: "torrent")()
-    console.print(
-        f"[cyan]Downloading [bold]{escape(torrent_name)}[/] from "
-        f"{status.num_seeds} seeds - {status.num_peers} peers[/]")
+    status_line = console.status(
+        f"[cyan]Downloading [bold]{escape(torrent_name)}[/] from {status.num_seeds} seeds - {status.num_peers} peers[/]",
+        spinner=None,
+    )
 
     cols = [
         TextColumn("[green]{task.description}[/] [orange1]{task.percentage:>6.2f}%[/]"),
@@ -388,13 +389,17 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
         TimeRemainingColumn(),
     ]
 
-    with Progress(*cols, console=console, transient=True) as progress:
-        task_id = progress.add_task("Progress", total=100.0)
-        while not handle.status().is_seeding:
-            s = handle.status()
-            progress.update(task_id, completed=s.progress * 100)
-            time.sleep(1)
-    progress.update(task_id, completed=100)
+    with status_line:
+        with Progress(*cols, console=console, transient=True) as progress:
+            task_id = progress.add_task("Progress", total=100.0)
+            while not handle.status().is_seeding:
+                s = handle.status()
+                progress.update(task_id, completed=s.progress * 100)
+                status_line.update(
+                    f"[cyan]Downloading [bold]{escape(torrent_name)}[/] from {s.num_seeds} seeds - {s.num_peers} peers[/]"
+                )
+                time.sleep(0.5)
+        progress.update(task_id, completed=100)
 
     console.print("[green]✔ Torrent download complete[/]")
 


### PR DESCRIPTION
## Summary
- use `console.status` to show torrent seeds/peers
- update status every 500 ms

## Testing
- `python3 -m py_compile bwget.py`


------
https://chatgpt.com/codex/tasks/task_e_6840187d826083209e2db7a6aba2abea