### PR TITLE
Handle unsupported URL schemes

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -496,7 +496,7 @@ def download(
 # CLI entry-point
 # ---------------------------------------------------------------------------
 def main() -> None:
-    global cfg
+    global cfg, EARLY_PB
 
     load_and_apply_config()
 
@@ -532,7 +532,15 @@ def main() -> None:
         sys.exit(1)
     ns = parser.parse_args()
 
-    global EARLY_PB
+    parsed_scheme = urlsplit(ns.url).scheme
+    if parsed_scheme and parsed_scheme.lower() not in {"http", "https"}:
+        if EARLY_PB:
+            EARLY_PB.stop()
+            EARLY_PB = None
+        console.print(
+            f"[red]⨯ Unsupported URL scheme: {parsed_scheme}. Only HTTP/HTTPS are supported.[/]")
+        sys.exit(2)
+
     if ns.quiet:
         if EARLY_PB:
             EARLY_PB.stop()


### PR DESCRIPTION
## Summary
- disallow non-HTTP/HTTPS URLs at startup
- stop the placeholder progress bar when encountering an unsupported scheme

## Testing
- `python -m py_compile bwget.py`
- `python bwget.py "magnet:?xt=urn:btih:a492f8b92a25b0399c87715fc228c864ac5a7bfb&dn=archlinux-2025.06.01-x86_64.iso" --sha256 06ee9907fef3a9843a5b1408bbb426cf5c703aa00ca191ee24daa7ddda82a6a7`

------
https://chatgpt.com/codex/tasks/task_e_684025f03a6c832081dfd054a9a2fa87