### PR TITLE
Fix torrent progress bar error

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -386,7 +386,7 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
         DownloadColumn(True),
         TransferSpeedColumn(),
         TimeRemainingColumn(),
-        TextColumn(lambda t: f"{t.fields.get('seeds', 0)} seeds - {t.fields.get('peers', 0)} peers"),
+        TextColumn("{task.fields[seeds]} seeds - {task.fields[peers]} peers"),
     ]
 
     with Progress(*cols, console=console, transient=True) as progress:


### PR DESCRIPTION
## Summary
- use TextColumn format string for seeds/peers display

## Testing
- `python bwget.py "magnet:?xt=urn:btih:a492f8b92a25b0399c87715fc228c864ac5a7bfb&dn=archlinux-2025.06.01-x86_64.iso" --sha256 06ee9907fef3a9843a5b1408bbb426cf5c703aa00ca191ee24daa7ddda82a6a7` *(terminated after start)*

------
https://chatgpt.com/codex/tasks/task_e_6840276c3e208320a5328cab68a7df71