### PR TITLE
Fix deprecated has_metadata usage

### DIFF
--- a/bwget.py
+++ b/bwget.py
@@ -380,7 +380,8 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
         f"[cyan]Downloading [bold]{escape(torrent_name)}[/]…[/]"
     )
 
-    while not handle.has_metadata():
+    # has_metadata() is deprecated in modern libtorrent; use torrent_status
+    while not handle.status().has_metadata:
         time.sleep(0.5)
 
     info = handle.torrent_file() if hasattr(handle, "torrent_file") else handle.get_torrent_info()


### PR DESCRIPTION
## Summary
- update torrent metadata polling to use `torrent_handle.status().has_metadata`

## Testing
- `python -m py_compile bwget.py`
- `python bwget.py "magnet:?xt=urn:btih:a492f8b92a25b0399c87715fc228c864ac5a7bfb&dn=archlinux-2025.06.01-x86_64.iso" --sha256 06ee9907fef3a9843a5b1408bbb426cf5c703aa00ca191ee24daa7ddda82a6a7` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68402afa30508320b771c8c38d1e8b98