### PR TITLE
Add user agent option

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,9 @@ bwget --sha256 0123456789abcdef... https://example.com/app.tar.gz
 # Use an HTTP proxy
 bwget --proxy http://proxy.local:3128 https://example.com/data.zip
 
+# Custom User-Agent
+bwget -U "MyDownloader/1.0" https://example.com/file.zip
+
 # Show version
 bwget --version
 ```

--- a/bwget.1
+++ b/bwget.1
@@ -29,12 +29,15 @@ file is present and the server supports HTTP range requests.  Supplying
 Suppress non-error output (hides the progress bar).
 .TP
 .B \-\-sha256 \fIDIGEST\fR
-Expected SHA-256 checksum (64 hex digits).  
+Expected SHA-256 checksum (64 hex digits).
 If omitted, bwget attempts to fetch \fI<URL>.sha256\fR automatically.
+.TP
+.B \-U, \-\-user-agent \fIUA\fR
+Override the HTTP User-Agent header with \fIUA\fR.
 .TP
 .B \-\-proxy \fIPROXY_URL\fR
 Use the specified HTTP/HTTPS proxy
-(e.g.\  \fIhttp://user:pass@host:port\fR).  
+(e.g.\  \fIhttp://user:pass@host:port\fR).
 Overrides any proxy defined in the config file or environment.
 .TP
 .B \-\-version

--- a/bwget.py
+++ b/bwget.py
@@ -661,6 +661,8 @@ def main() -> None:
     parser.add_argument("--sha256", metavar="HEXDIGEST",
                         help="expected SHA-256 (64 hex chars). "
                              "Auto-fetches <URL>.sha256 if not given.")
+    parser.add_argument("-U", "--user-agent", metavar="UA",
+                        help="override User-Agent header")
     parser.add_argument("--proxy", metavar="PROXY_URL",
                         help="HTTP/HTTPS proxy URL "
                              "(e.g., http://user:pass@host:port)")
@@ -678,6 +680,9 @@ def main() -> None:
             EARLY_PB.stop()
             EARLY_PB = None
         console.quiet = True
+
+    if ns.user_agent:
+        cfg["user_agent"] = ns.user_agent
 
     proxy_url_str_to_use = ns.proxy or cfg["proxy_url_config"]
     if proxy_url_str_to_use:


### PR DESCRIPTION
## Summary
- allow overriding the User-Agent via `-U/--user-agent`
- document the new CLI option in README and manpage

## Testing
- `python3 -m py_compile bwget.py`
- `python3 bwget.py --help | sed -n '10,22p'`

------
https://chatgpt.com/codex/tasks/task_e_684041a8909083208bf8eb9bfd3b5ca0