### PR TITLE
Add input file support for batch downloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 * TLS verification and proxy support (CLI, config file, or environment variables)
 * Automatic retries with exponential backoff
 * Optional SHA‑256 checksum verification (auto-fetch `<URL>.sha256`)
+* Batch downloads from a file (`-i urls.txt`)
 * Configuration via TOML (`~/.config/bwget/config.toml`)
 
 ## Requirements
@@ -88,6 +89,9 @@ bwget --sha256 0123456789abcdef... https://example.com/app.tar.gz
 
 # Use an HTTP proxy
 bwget --proxy http://proxy.local:3128 https://example.com/data.zip
+
+# Download many URLs from a file
+bwget -i urls.txt
 
 # Show version
 bwget --version

--- a/bwget.1
+++ b/bwget.1
@@ -3,7 +3,7 @@
 bwget \- “Better Wget” in Python
 .SH SYNOPSIS
 .B bwget
-URL [\fIoptions\fR]
+[\fIoptions\fR] URL
 
 .SH DESCRIPTION
 \fBbwget\fR is a tiny, single-file Python replacement for the most-used parts
@@ -28,8 +28,12 @@ file is present and the server supports HTTP range requests.  Supplying
 .B \-q, \-\-quiet
 Suppress non-error output (hides the progress bar).
 .TP
+.B \-i, \-\-input \fIFILE\fR
+Read URLs from \fIFILE\fR (one per line). Lines starting with '#'
+are ignored.
+.TP
 .B \-\-sha256 \fIDIGEST\fR
-Expected SHA-256 checksum (64 hex digits).  
+Expected SHA-256 checksum (64 hex digits).
 If omitted, bwget attempts to fetch \fI<URL>.sha256\fR automatically.
 .TP
 .B \-\-proxy \fIPROXY_URL\fR
@@ -83,6 +87,9 @@ Verify SHA-256 while downloading:
 .TP
 Download through a proxy:
 .B bwget \-\-proxy http://proxy.local:3128 https://example.com/data.zip
+.TP
+Download a batch of URLs from a file:
+.B bwget \-i urls.txt
 
 .SH SEE ALSO
 wget(1), curl(1)

--- a/bwget.py
+++ b/bwget.py
@@ -645,7 +645,11 @@ def main() -> None:
         description=__doc__.splitlines()[2].strip(),
         formatter_class=argparse.RawTextHelpFormatter,
     )
-    parser.add_argument("url", help="HTTP(S) URL to fetch")
+    parser.add_argument("url", nargs="?", help="HTTP(S) URL to fetch")
+    parser.add_argument(
+        "-i", "--input", metavar="FILE",
+        help="read URLs from FILE (one per line)"
+    )
     parser.add_argument("-o", "--output", metavar="FILE",
                         help="explicit output filename/path")
     # Default is now to *resume* automatically.
@@ -699,31 +703,59 @@ def main() -> None:
     else:
         cfg["final_proxies_dict"] = None
 
-    req_hdrs     = {"User-Agent": cfg["user_agent"]}
-    expected_sha = (ns.sha256.lower()
-                    if ns.sha256 else fetch_remote_sha256(ns.url, req_hdrs))
+    req_hdrs = {"User-Agent": cfg["user_agent"]}
 
-    if ns.sha256 and (not expected_sha or len(expected_sha) != 64
-                      or not all(c in "0123456789abcdefABCDEF" for c in expected_sha)):
-        console.print("[red]⨯ Invalid SHA-256 provided (must be 64 hex chars).[/]")
-        sys.exit(2)
+    urls: list[str] = []
+    if ns.url:
+        urls.append(ns.url)
+    if ns.input:
+        try:
+            with open(ns.input, "r", encoding="utf-8") as f:
+                for line in f:
+                    url = line.strip()
+                    if url and not url.startswith("#"):
+                        urls.append(url)
+        except Exception as e:
+            console.print(f"[red]⨯ Could not read input file {ns.input}: {e}[/]")
+            sys.exit(1)
 
-    if expected_sha and len(expected_sha) != 64:
-        console.print(f"[red]⨯ Fetched SHA-256 invalid (len {len(expected_sha)}).[/]")
-        expected_sha = None
+    if not urls:
+        console.print("[red]⨯ No URL provided.[/]")
+        sys.exit(1)
 
-    if is_torrent(ns.url):
-        out_dir = Path(ns.output).expanduser() if ns.output else Path('.')
-        download_torrent(ns.url, out_dir, expected_sha)
-    else:
-        initial_path = pick_initial_filename(ns.url, ns.output)
-        download(
-            ns.url,
-            initial_path,
-            ns.output is not None,
-            ns.resume,
-            expected_sha,
-        )
+    for url in urls:
+        expected_sha = ns.sha256.lower() if ns.sha256 else fetch_remote_sha256(url, req_hdrs)
+
+        if ns.sha256 and (
+            not expected_sha
+            or len(expected_sha) != 64
+            or not all(c in "0123456789abcdefABCDEF" for c in expected_sha)
+        ):
+            console.print("[red]⨯ Invalid SHA-256 provided (must be 64 hex chars). Skipping.[/]")
+            continue
+
+        if expected_sha and len(expected_sha) != 64:
+            console.print(f"[red]⨯ Fetched SHA-256 invalid (len {len(expected_sha)}).[/]")
+            expected_sha = None
+
+        try:
+            if is_torrent(url):
+                out_dir = Path(ns.output).expanduser() if ns.output else Path('.')
+                download_torrent(url, out_dir, expected_sha)
+            else:
+                initial_path = pick_initial_filename(url, ns.output)
+                download(
+                    url,
+                    initial_path,
+                    ns.output is not None,
+                    ns.resume,
+                    expected_sha,
+                )
+        except SystemExit as exc:
+            if int(getattr(exc, "code", 1)) == 130:
+                raise
+            # Errors already reported; continue with next URL
+            continue
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- support reading multiple URLs from a file via `-i/--input`
- continue with remaining URLs when a download fails
- document the new feature in README and manpage

## Testing
- `python3 -m py_compile bwget.py`

------
https://chatgpt.com/codex/tasks/task_e_684041ac654c8320993230f08221d3a9