### PR TITLE
Add --no-check-certificate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 * .torrent and magnet link support (single torrent at a time, no seeding)
 * Automatic filename selection (from URL or **Content-Disposition** header)
 * Resume support for partially downloaded files (HTTP range requests)
-* TLS verification and proxy support (CLI, config file, or environment variables)
+* TLS verification (can be disabled with `--no-check-certificate`, insecure!) and proxy support (CLI, config file, or environment variables)
 * Automatic retries with exponential backoff
 * Optional SHA‑256 checksum verification (auto-fetch `<URL>.sha256`)
 * Configuration via TOML (`~/.config/bwget/config.toml`)
@@ -89,6 +89,10 @@ bwget --sha256 0123456789abcdef... https://example.com/app.tar.gz
 # Use an HTTP proxy
 bwget --proxy http://proxy.local:3128 https://example.com/data.zip
 
+# Disable TLS verification (insecure)
+bwget --no-check-certificate https://example.com/file.tar.gz
+# This makes the connection vulnerable to man-in-the-middle attacks.
+
 # Show version
 bwget --version
 ```
@@ -115,6 +119,7 @@ max_retries = 3
 base_backoff = 1.0
 request_timeout = 15
 stream_timeout = 30
+verify_tls = true
 
 [download]
 chunk_size_kb = 256

--- a/bwget.1
+++ b/bwget.1
@@ -10,7 +10,8 @@ URL [\fIoptions\fR]
 of GNU wget.  
 It supports HTTP/HTTPS downloads with a nice progress bar, .torrent and magnet
 link handling (single torrent at a time, no seeding), automatic filename
-selection, automatic \fIresume\fR (now the default), TLS verification,
+selection, automatic \fIresume\fR (now the default), TLS verification
+(can be disabled with \fB--no-check-certificate\fR, insecure),
 automatic retries with exponential back-off, optional SHA-256 verification,
 proxy support, and user configuration via a TOML file.
 
@@ -34,8 +35,11 @@ If omitted, bwget attempts to fetch \fI<URL>.sha256\fR automatically.
 .TP
 .B \-\-proxy \fIPROXY_URL\fR
 Use the specified HTTP/HTTPS proxy
-(e.g.\  \fIhttp://user:pass@host:port\fR).  
+(e.g.\  \fIhttp://user:pass@host:port\fR).
 Overrides any proxy defined in the config file or environment.
+.TP
+.B \-\-no-check-certificate
+Skip TLS certificate verification (\fIDANGEROUS\fR; vulnerable to MITM).
 .TP
 .B \-\-version
 Display version information and exit.
@@ -53,6 +57,8 @@ max_retries      = 3
 base_backoff     = 1.0
 request_timeout  = 15
 stream_timeout   = 30
+# verify TLS certificates (set to false to disable verification)
+verify_tls      = true
 # proxy          = "http://user:pass@proxy:8080"
 
 [download]

--- a/bwget.py
+++ b/bwget.py
@@ -94,6 +94,7 @@ cfg = {
     "request_timeout": 15, "stream_timeout": 30,
     "chunk_size": 1 << 18, "hash_chunk_size": 1 << 20,
     "proxy_url_config": None, "final_proxies_dict": None,
+    "verify_tls": True,
 }
 
 TRANSIENT_STATUS = {500, 502, 503, 504}
@@ -126,6 +127,7 @@ max_retries = {cfg['max_retries']}
 base_backoff = {cfg['base_backoff']:.1f}
 request_timeout = {cfg['request_timeout']}
 stream_timeout = {cfg['stream_timeout']}
+verify_tls = true
 
 [download]
 chunk_size_kb = {cfg['chunk_size'] // 1024}
@@ -169,6 +171,7 @@ def load_and_apply_config():
         "request_timeout": int(net_conf.get("request_timeout", cfg["request_timeout"])),
         "stream_timeout": int(net_conf.get("stream_timeout", cfg["stream_timeout"])),
         "proxy_url_config": net_conf.get("proxy"),
+        "verify_tls": bool(net_conf.get("verify_tls", cfg["verify_tls"])),
         "chunk_size": int(dl_conf.get("chunk_size_kb", cfg["chunk_size"] // 1024)) * 1024,
         "hash_chunk_size": int(dl_conf.get("hash_chunk_size_mb", cfg["hash_chunk_size"] // (1024*1024))) * 1024 * 1024,
     })
@@ -198,6 +201,7 @@ def request_head(url: str, headers: dict) -> requests.Response | None:
             timeout=cfg["request_timeout"],
             headers=headers,
             proxies=cfg["final_proxies_dict"],
+            verify=cfg["verify_tls"],
         )
     except RequestException as e:
         console.print(f"[yellow]ⓘ HEAD request failed for {shorten(url, 70)}: {e}[/]", highlight=True)
@@ -212,6 +216,7 @@ def fetch_remote_sha256(url: str, headers: dict) -> str | None:
             timeout=cfg["request_timeout"],
             headers=headers,
             proxies=cfg["final_proxies_dict"],
+            verify=cfg["verify_tls"],
         )
         r.raise_for_status()
         first_line = r.text.strip().splitlines()[0]
@@ -241,6 +246,7 @@ def _open_stream(url: str, stream_headers: dict[str, str]) -> requests.Response:
                 headers=stream_headers,
                 timeout=cfg["stream_timeout"],
                 proxies=cfg["final_proxies_dict"],
+                verify=cfg["verify_tls"],
             )
             r.raise_for_status()
             return r
@@ -361,6 +367,7 @@ def download_torrent(url: str, out_dir: Path, expected_sha256: str | None = None
             timeout=cfg["request_timeout"],
             headers={"User-Agent": cfg["user_agent"]},
             proxies=cfg["final_proxies_dict"],
+            verify=cfg["verify_tls"],
         )
         r.raise_for_status()
         with tempfile.NamedTemporaryFile(delete=False) as tf:
@@ -664,6 +671,11 @@ def main() -> None:
     parser.add_argument("--proxy", metavar="PROXY_URL",
                         help="HTTP/HTTPS proxy URL "
                              "(e.g., http://user:pass@host:port)")
+    parser.add_argument(
+        "--no-check-certificate",
+        action="store_true",
+        help="disable TLS certificate verification (INSECURE)",
+    )
     parser.add_argument("--version", action="version",
                         version=f"%(prog)s {VERSION}")
 
@@ -671,6 +683,7 @@ def main() -> None:
         parser.print_help(sys.stderr)
         sys.exit(1)
     ns = parser.parse_args()
+    cfg["verify_tls"] = not ns.no_check_certificate
 
     global EARLY_PB
     if ns.quiet:


### PR DESCRIPTION
## Summary
- allow disabling TLS verification via CLI
- propagate TLS verification setting to HTTP requests
- document new option and security implications in README and manpage
- include `verify_tls` setting in sample config

## Testing
- `python bwget.py --help | head`
- `python -m py_compile bwget.py`
- `python bwget.py https://example.com/ -o /tmp/example.html --no-check-certificate` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684041aadbb08320ae77beb94e5fac01