### PR TITLE
Add authentication option

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 * Automatic filename selection (from URL or **Content-Disposition** header)
 * Resume support for partially downloaded files (HTTP range requests)
 * TLS verification and proxy support (CLI, config file, or environment variables)
+* Optional HTTP authentication via `--auth`
 * Automatic retries with exponential backoff
 * Optional SHA‑256 checksum verification (auto-fetch `<URL>.sha256`)
 * Configuration via TOML (`~/.config/bwget/config.toml`)
@@ -88,6 +89,12 @@ bwget --sha256 0123456789abcdef... https://example.com/app.tar.gz
 
 # Use an HTTP proxy
 bwget --proxy http://proxy.local:3128 https://example.com/data.zip
+
+# Authenticate with Basic credentials
+bwget --auth user:pass https://example.com/secure/file
+
+# Authenticate with a Bearer token
+bwget --auth ABCDEFGH12345678 https://api.example.com/data
 
 # Show version
 bwget --version

--- a/bwget.1
+++ b/bwget.1
@@ -12,7 +12,7 @@ It supports HTTP/HTTPS downloads with a nice progress bar, .torrent and magnet
 link handling (single torrent at a time, no seeding), automatic filename
 selection, automatic \fIresume\fR (now the default), TLS verification,
 automatic retries with exponential back-off, optional SHA-256 verification,
-proxy support, and user configuration via a TOML file.
+proxy support, optional HTTP authentication, and user configuration via a TOML file.
 
 .SH OPTIONS
 .TP
@@ -34,8 +34,13 @@ If omitted, bwget attempts to fetch \fI<URL>.sha256\fR automatically.
 .TP
 .B \-\-proxy \fIPROXY_URL\fR
 Use the specified HTTP/HTTPS proxy
-(e.g.\  \fIhttp://user:pass@host:port\fR).  
+(e.g.\  \fIhttp://user:pass@host:port\fR).
 Overrides any proxy defined in the config file or environment.
+.TP
+.B \-\-auth \fICRED\fR
+HTTP Basic credentials (\fIuser:pass\fR) or a Bearer token. If
+\fICRED\fR contains a colon, it is treated as a username and password;
+otherwise it is used as a Bearer token.
 .TP
 .B \-\-version
 Display version information and exit.
@@ -83,6 +88,12 @@ Verify SHA-256 while downloading:
 .TP
 Download through a proxy:
 .B bwget \-\-proxy http://proxy.local:3128 https://example.com/data.zip
+.TP
+Authenticate with Basic credentials:
+.B bwget \-\-auth user:pass https://example.com/secure/file
+.TP
+Authenticate with a Bearer token:
+.B bwget \-\-auth ABCDEFGH12345678 https://api.example.com/data
 
 .SH SEE ALSO
 wget(1), curl(1)


### PR DESCRIPTION
## Summary
- support authentication with `--auth` for basic or bearer token
- document new option in README and bwget.1
- update help text and internal description

## Testing
- `python3 -m py_compile bwget.py`
- `python3 bwget.py --version`
- `python3 bwget.py --help | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_684041ab961c8320875cea15ccc41600