### PR TITLE
Add new TOML options for torrent and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,8 @@ On first launch, bwget creates a default configuration at:
 ~/.config/bwget/config.toml
 ```
 
-Customize settings like proxies, retries, timeouts, and chunk sizes directly:
+Customize settings like proxies, retries, timeouts, chunk sizes, default resume
+behavior and torrent options directly:
 
 ```toml
 [network]
@@ -177,6 +178,10 @@ verify_tls = true
 [download]
 chunk_size_kb = 256
 hash_chunk_size_mb = 1
+resume_default = true
+
+[torrent]
+listen_interfaces = "0.0.0.0:6881-6891"
 ```
 
 ---

--- a/bwget.1
+++ b/bwget.1
@@ -71,6 +71,10 @@ verify_tls      = true
 [download]
 chunk_size_kb      = 256
 hash_chunk_size_mb = 1
+resume_default    = true
+
+[torrent]
+listen_interfaces = "0.0.0.0:6881-6891"
 .fi
 
 .SH EXIT STATUS


### PR DESCRIPTION
## Summary
- allow configuring torrent listen interfaces and default resume behavior
- document new `resume_default` and `[torrent]` options in README and manpage
- use config defaults when parsing CLI

## Testing
- `python3 -m py_compile bwget.py`


------
https://chatgpt.com/codex/tasks/task_e_6840a89613fc8320996044d2adc8207f