### PR TITLE
Add libtorrent dependency to spec

### DIFF
--- a/bwget.spec
+++ b/bwget.spec
@@ -12,10 +12,12 @@ BuildArch:      noarch
 # Build-time dependencies
 BuildRequires:  python3-devel
 BuildRequires:  python3dist(requests) python3dist(rich)
+BuildRequires:  python3dist(libtorrent)
 BuildRequires:  (python3dist(tomli) if %{python3_pkgversion} < 3.11)
 
 # Runtime dependencies – same list
 Requires:       python3dist(requests) python3dist(rich)
+Requires:       python3dist(libtorrent)
 Requires:       (python3dist(tomli) if %{python3_pkgversion} < 3.11)
 
 %description


### PR DESCRIPTION
## Summary
- tweak Fedora spec to build with torrent support

## Testing
- `python3 bwget.py --version`
- `python3 -m py_compile bwget.py`


------
https://chatgpt.com/codex/tasks/task_e_685bf86f08608320b1148a979553ba2c