### PR TITLE
Fix packaging checksums

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -10,9 +10,9 @@ pkgbase = bwget
        depends = python-rich
        depends = python-libtorrent
        depends = python-tomli
-	source = bwget.py
-	source = bwget.1
-       sha256sums = 2a7c2904cf096999601068b6cf40b4daffde76c25e7f592184945433863015f0
-       sha256sums = 5589b53c6d3ed396a37ee7b19f49b78387e01606698fa3fd35d726fb304cd7ce
+       source = bwget.py
+       source = bwget.1
+       sha256sums = bee8bac671b028cc3b293f4e870fd4dbf536a18bc137fcddd37b5c806f5f03e9
+       sha256sums = 42385ac8e16d52fb05c727e6445db8bd1b7f65f4de03936febe812ec11bac2e8
 
 pkgname = bwget

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -10,8 +10,8 @@ depends=('python' 'python-requests' 'python-rich' 'python-libtorrent' 'python-to
 source=("bwget.py"
         "bwget.1")
 sha256sums=(
-  '2a7c2904cf096999601068b6cf40b4daffde76c25e7f592184945433863015f0'
-  '5589b53c6d3ed396a37ee7b19f49b78387e01606698fa3fd35d726fb304cd7ce'
+  'bee8bac671b028cc3b293f4e870fd4dbf536a18bc137fcddd37b5c806f5f03e9'
+  '42385ac8e16d52fb05c727e6445db8bd1b7f65f4de03936febe812ec11bac2e8'
 )
 
 prepare() {


### PR DESCRIPTION
## Summary
- update sha256sums for `bwget.py` and `bwget.1` in `PKGBUILD`
- sync `.SRCINFO` with new checksums

## Testing
- `python3 -m py_compile bwget.py`

------
https://chatgpt.com/codex/tasks/task_e_685c0d772fb88320a2161cc59a55011f